### PR TITLE
Add additional success purchase listener ios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Use dictionaryWithObjectsAndKeys in NSDictionary to fetch product values. This will prevent from NSInvalidArgumentException in ios which rarely occurs.
 * Fixed wrong npe in `android` when `getAvailablePurchases`.
 + Only parse `orderId` when exists in `Android` to prevent crashing.
++ Add additional success purchase listener in `iOS`. Related [#54](https://github.com/dooboolab/flutter_inapp_purchase/issues/54)
 
 ## 0.7.1
 * Implemented receiptValidation for both android and ios.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For help on editing plugin code, view the [documentation](https://flutter.io/dev
 | getAppStoreInitiatedProducts | | `List<IAPItem>` | If the user has initiated a purchase directly on the App Store, the products that the user is attempting to purchase will be returned here. (iOS only) Note: On iOS versions earlier than 11.0 this method will always return an empty list, as the functionality was introduced in v11.0. [See Apple Docs for more info](https://developer.apple.com/documentation/storekit/skpaymenttransactionobserver/2877502-paymentqueue) Always returns an empty list on Android.
 | buySubscription | `string` Subscription ID/sku, `string` Old Subscription ID/sku (on Android) | `PurchasedItem` | Create (buy) a subscription to a sku. For upgrading/downgrading subscription on Android pass second parameter with current subscription ID, on iOS this is handled automatically by store. |
 | buyProduct | `string` Product ID/sku | `PurchasedItem` | Buy a product |
-| buyProductWithoutFinishTransaction | `string` Product ID/sku | `PurchasedItem` | Buy a product without finish transaction call (iOS only) |
+| ~~buyProductWithoutFinishTransaction~~ | `string` Product ID/sku | `PurchasedItem` | Buy a product without finish transaction call (iOS only) |
 | finishTransaction | `void` | `String` | Send finishTransaction call to Apple IAP server. Call this function after receipt validation process |
 | consumePurchase | `String` Purchase token | `String` | Consume a product (on Android.) No-op on iOS. |
 | endConnection | | `String` | End billing connection (on Android.) No-op on iOS. |

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
 analyzer:
   strong-mode:
-    implicit-casts: false
+    implicit-casts: true
     implicit-dynamic: false

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		27672194C9D5FA8DDDF731B8 /* libPods-Runner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A72A37C715E27BACEF745D36 /* libPods-Runner.a */; };
-		2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */ = {isa = PBXBuildFile; fileRef = 2D5378251FAA1A9400D5DBA9 /* flutter_assets */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
 		3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -42,7 +41,6 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		2D5378251FAA1A9400D5DBA9 /* flutter_assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = flutter_assets; path = Flutter/flutter_assets; sourceTree = SOURCE_ROOT; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		3B80C3931E831B6300D905FE /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -85,7 +83,6 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
-				2D5378251FAA1A9400D5DBA9 /* flutter_assets */,
 				3B80C3931E831B6300D905FE /* App.framework */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEBA1CF902C7004384FC /* Flutter.framework */,
@@ -214,7 +211,6 @@
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				9740EEB41CF90195004384FC /* Debug.xcconfig in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
-				2D5378261FAA1A9400D5DBA9 /* flutter_assets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Classes/FlutterInappPurchasePlugin.m
+++ b/ios/Classes/FlutterInappPurchasePlugin.m
@@ -328,6 +328,9 @@
         [requestedPayments removeObjectForKey:transaction.payment];
     }
     [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
+
+    // additionally send event
+    [self.channel invokeMethod:@"iap-purchase-event" arguments: purchase];
 }
 
 - (NSDictionary *)getPurchaseData:(SKPaymentTransaction *)transaction {

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -82,7 +82,7 @@ class FlutterInappPurchase {
     if (skus == null || skus.contains(null)) return [];
     skus = skus.toList();
     if (Platform.isAndroid) {
-      dynamic result = await _channel.invokeMethod(
+      dynamic result = await _channel.invokeMethod<dynamic>(
         'getItemsByType',
         <String, dynamic>{
           'type': _typeInApp[0],
@@ -92,7 +92,7 @@ class FlutterInappPurchase {
 
       return extractItems(result);
     } else if (Platform.isIOS) {
-      dynamic result = await _channel.invokeMethod(
+      dynamic result = await _channel.invokeMethod<dynamic>(
         'getItems',
         {
           'skus': skus,
@@ -112,7 +112,7 @@ class FlutterInappPurchase {
     if (skus == null || skus.contains(null)) return [];
     skus = skus.toList();
     if (Platform.isAndroid) {
-      dynamic result = await _channel.invokeMethod(
+      dynamic result = await _channel.invokeMethod<dynamic>(
         'getItemsByType',
         <String, dynamic>{
           'type': _typeInApp[1],
@@ -122,7 +122,7 @@ class FlutterInappPurchase {
 
       return extractItems(result);
     } else if (Platform.isIOS) {
-      dynamic result = await _channel.invokeMethod(
+      dynamic result = await _channel.invokeMethod<dynamic>(
         'getItems',
         {
           'skus': skus,
@@ -141,14 +141,14 @@ class FlutterInappPurchase {
   /// Identical to [getAvailablePurchases] on `iOS`.
   static Future<List<PurchasedItem>> getPurchaseHistory() async {
     if (Platform.isAndroid) {
-      dynamic result1 = await _channel.invokeMethod(
+      dynamic result1 = await _channel.invokeMethod<dynamic>(
         'getPurchaseHistoryByType',
         <String, dynamic>{
           'type': _typeInApp[0],
         },
       );
 
-      dynamic result2 = await _channel.invokeMethod(
+      dynamic result2 = await _channel.invokeMethod<dynamic>(
         'getPurchaseHistoryByType',
         <String, dynamic>{
           'type': _typeInApp[1],
@@ -157,7 +157,8 @@ class FlutterInappPurchase {
 
       return extractPurchased(result1) + extractPurchased(result2);
     } else if (Platform.isIOS) {
-      dynamic result = await _channel.invokeMethod('getAvailableItems');
+      dynamic result =
+          await _channel.invokeMethod<dynamic>('getAvailableItems');
 
       return extractPurchased(json.encode(result));
     }
@@ -170,14 +171,14 @@ class FlutterInappPurchase {
   /// This is identical to [getPurchaseHistory] on `iOS`
   static Future<List<PurchasedItem>> getAvailablePurchases() async {
     if (Platform.isAndroid) {
-      dynamic result1 = await _channel.invokeMethod(
+      dynamic result1 = await _channel.invokeMethod<dynamic>(
         'getAvailableItemsByType',
         <String, dynamic>{
           'type': _typeInApp[0],
         },
       );
 
-      dynamic result2 = await _channel.invokeMethod(
+      dynamic result2 = await _channel.invokeMethod<dynamic>(
         'getAvailableItemsByType',
         <String, dynamic>{
           'type': _typeInApp[1],
@@ -186,7 +187,8 @@ class FlutterInappPurchase {
 
       return extractPurchased(result1) + extractPurchased(result2);
     } else if (Platform.isIOS) {
-      dynamic result = await _channel.invokeMethod('getAvailableItems');
+      dynamic result =
+          await _channel.invokeMethod<dynamic>('getAvailableItems');
 
       return extractPurchased(json.encode(result));
     }
@@ -199,8 +201,8 @@ class FlutterInappPurchase {
   /// Identical to [buySubscription] on `iOS`.
   static Future<PurchasedItem> buyProduct(String sku) async {
     if (Platform.isAndroid) {
-      dynamic result =
-          await _channel.invokeMethod('buyItemByType', <String, dynamic>{
+      dynamic result = await _channel
+          .invokeMethod<dynamic>('buyItemByType', <String, dynamic>{
         'type': _typeInApp[0],
         'sku': sku,
         'oldSku': null, //TODO can this be removed?
@@ -211,8 +213,8 @@ class FlutterInappPurchase {
 
       return item;
     } else if (Platform.isIOS) {
-      dynamic result = await _channel
-          .invokeMethod('buyProductWithFinishTransaction', <String, dynamic>{
+      dynamic result = await _channel.invokeMethod<dynamic>(
+          'buyProductWithFinishTransaction', <String, dynamic>{
         'sku': sku,
       });
       result = json.encode(result);
@@ -233,8 +235,8 @@ class FlutterInappPurchase {
   static Future<PurchasedItem> buySubscription(String sku,
       {String oldSku}) async {
     if (Platform.isAndroid) {
-      dynamic result =
-          await _channel.invokeMethod('buyItemByType', <String, dynamic>{
+      dynamic result = await _channel
+          .invokeMethod<dynamic>('buyItemByType', <String, dynamic>{
         'type': _typeInApp[1],
         'sku': sku,
         'oldSku': oldSku,
@@ -244,8 +246,8 @@ class FlutterInappPurchase {
       PurchasedItem item = PurchasedItem.fromJSON(param);
       return item;
     } else if (Platform.isIOS) {
-      dynamic result = await _channel
-          .invokeMethod('buyProductWithFinishTransaction', <String, dynamic>{
+      dynamic result = await _channel.invokeMethod<dynamic>(
+          'buyProductWithFinishTransaction', <String, dynamic>{
         'sku': sku,
       });
       result = json.encode(result);
@@ -300,8 +302,8 @@ class FlutterInappPurchase {
   static Future<PurchasedItem> buyProductWithoutFinishTransaction(
       String sku) async {
     if (Platform.isAndroid) {
-      dynamic result =
-          await _channel.invokeMethod('buyItemByType', <String, dynamic>{
+      dynamic result = await _channel
+          .invokeMethod<dynamic>('buyItemByType', <String, dynamic>{
         'type': _typeInApp[0],
         'sku': sku,
         'oldSku': null,
@@ -311,8 +313,8 @@ class FlutterInappPurchase {
       PurchasedItem item = PurchasedItem.fromJSON(param);
       return item;
     } else if (Platform.isIOS) {
-      dynamic result = await _channel
-          .invokeMethod('buyProductWithoutFinishTransaction', <String, dynamic>{
+      dynamic result = await _channel.invokeMethod<dynamic>(
+          'buyProductWithoutFinishTransaction', <String, dynamic>{
         'sku': sku,
       });
       result = json.encode(result);
@@ -348,7 +350,7 @@ class FlutterInappPurchase {
       return List<IAPItem>();
     } else if (Platform.isIOS) {
       dynamic result =
-          await _channel.invokeMethod('getAppStoreInitiatedProducts');
+          await _channel.invokeMethod<dynamic>('getAppStoreInitiatedProducts');
 
       return extractItems(json.encode(result));
     }

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -262,15 +262,27 @@ class FlutterInappPurchase {
       PurchasedItem item = PurchasedItem.fromJSON(param);
       return item;
     } else if (Platform.isIOS) {
-      dynamic result = await _channel.invokeMethod<dynamic>(
-          'buyProductWithFinishTransaction', <String, dynamic>{
-        'sku': sku,
-      });
-      result = json.encode(result);
+      try {
+        dynamic result = await _channel.invokeMethod<dynamic>(
+            'buyProductWithFinishTransaction', <String, dynamic>{
+          'sku': sku,
+        });
+        result = json.encode(result);
 
-      Map<String, dynamic> param = json.decode(result.toString());
-      PurchasedItem item = PurchasedItem.fromJSON(param);
-      return item;
+        Map<String, dynamic> param = json.decode(result.toString());
+        PurchasedItem item = PurchasedItem.fromJSON(param);
+        return item;
+      } catch (err) {
+        print('Caused err. Set additionalSuccessPurchaseListenerIOS.');
+        print(err);
+        await _addAdditionalSuccessPurchaseListenerIOS();
+        _purchaseSub = onAdditionalSuccessPurchaseIOS.listen((data) {
+          _removePurchaseListener();
+          Map<String, dynamic> param = json.decode(data.toString());
+          PurchasedItem item = PurchasedItem.fromJSON(param);
+          return item;
+        });
+      }
     }
     throw PlatformException(
         code: Platform.operatingSystem, message: "platform not supported");

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -327,6 +327,7 @@ class FlutterInappPurchase {
   /// This allows you to perform server-side validation before finalizing the transaction on screen.
   ///
   /// No effect on `Android`, who does not allow this type of functionality.
+  @deprecated
   static Future<PurchasedItem> buyProductWithoutFinishTransaction(
       String sku) async {
     if (Platform.isAndroid) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/dooboolab/flutter_inapp_purchase/blob/master/pubspe
 environment:
   sdk: '>=1.20.1 <3.0.0'
 dependencies:
-  http: '>=0.11.3+16 <1.0.0'
+  http: '>=0.12.0 <1.0.0'
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
This feature came from the support of feature in [react-native-iap](https://www.google.com/search?q=react-native-iap&oq=react-native-iap&aqs=chrome..69i57j69i60l3j69i57j69i59.1371j0j7&sourceid=chrome&ie=UTF-8). Related issue in [#307](https://github.com/dooboolab/react-native-iap/issues/307).

Related issue in current repo: #54 

Description
- Unlike what I've done in `react-native-iap`, I've tried to manage `rejection` inside `plugin` so that additional success event will be received in the method itself and hopefully delivered to `buyProduct` and `buySubscription`.
- Also, deprecate `buyProductWithoutFinishTransanction` when this feature is implemented.