### PR TITLE
Improved getPurchaseHistory's speed 44% faster

### DIFF
--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -145,21 +145,25 @@ class FlutterInappPurchase {
   /// Identical to [getAvailablePurchases] on `iOS`.
   static Future<List<PurchasedItem>> getPurchaseHistory() async {
     if (Platform.isAndroid) {
-      dynamic result1 = await _channel.invokeMethod(
+      Future<dynamic> getInappPurchaseHistory = _channel.invokeMethod(
         'getPurchaseHistoryByType',
         <String, dynamic>{
           'type': _typeInApp[0],
         },
       );
 
-      dynamic result2 = await _channel.invokeMethod(
+      Future<dynamic> getSubsPurchaseHistory = _channel.invokeMethod(
         'getPurchaseHistoryByType',
         <String, dynamic>{
           'type': _typeInApp[1],
         },
       );
 
-      return extractPurchased(result1) + extractPurchased(result2);
+      List<dynamic> results = await Future.wait(
+          [getInappPurchaseHistory, getSubsPurchaseHistory]);
+
+      return results.reduce((result1, result2) =>
+      extractPurchased(result1) + extractPurchased(result2));
     } else if (Platform.isIOS) {
       dynamic result =
           await _channel.invokeMethod('getAvailableItems');


### PR DESCRIPTION
- It took 754982 microseconds to call getPurchaseHistory before, but it was able to improve to 418823 microseconds.
- I think the order of execution of the functions is not important so I used `Future.wait`.