### PR TITLE
Fix double call of result reply on connection init

### DIFF
--- a/android/src/main/java/com/dooboolab/flutterinapppurchase/AndroidInappPurchasePlugin.java
+++ b/android/src/main/java/com/dooboolab/flutterinapppurchase/AndroidInappPurchasePlugin.java
@@ -72,6 +72,8 @@ public class AndroidInappPurchasePlugin implements MethodCallHandler {
           .enablePendingPurchases()
           .build();
       billingClient.startConnection(new BillingClientStateListener() {
+        private boolean alreadyFinished = false;
+
         @Override
         public void onBillingSetupFinished(BillingResult billingResult) {
           try {
@@ -81,11 +83,15 @@ public class AndroidInappPurchasePlugin implements MethodCallHandler {
               JSONObject item = new JSONObject();
               item.put("connected", true);
               channel.invokeMethod("connection-updated", item.toString());
+              if (alreadyFinished) return;
+              alreadyFinished = true;
               result.success("Billing client ready");
             } else {
               JSONObject item = new JSONObject();
               item.put("connected", false);
               channel.invokeMethod("connection-updated", item.toString());
+              if (alreadyFinished) return;
+              alreadyFinished = true;
               result.error(call.method, "responseCode: " + responseCode, "");
             }
           } catch (JSONException je) {


### PR DESCRIPTION
Fixes #106 

I've been debugging and looking for possible reasons for "Reply already submitted" message that I've been able to catch on my own device and the only thing that could cause it is calling `result.success` or `result.error` twice or more on `onBillingSetupFinished `. And digging into the RN IAP lib led me to this quite similar problem occurred once not so long ago https://github.com/dooboolab/react-native-iap/issues/315

This improvement should protect the `result` and ensure it is replied no more than once.