### PR TITLE
Add PurchasedItem.transactionStateIOS

### DIFF
--- a/ios/Classes/FlutterInappPurchasePlugin.m
+++ b/ios/Classes/FlutterInappPurchasePlugin.m
@@ -192,6 +192,7 @@
                                                      item.transactionIdentifier, @"transactionId",
                                                      item.payment.productIdentifier, @"productId",
                                                      [receiptData base64EncodedStringWithOptions:0], @"transactionReceipt",
+                                                     [NSNumber numberWithInt: item.transactionState], @"transactionStateIOS",
                                                      nil
                                                      ];
                     [output addObject:purchase];
@@ -578,6 +579,7 @@
                                              transaction.transactionIdentifier, @"transactionId",
                                              transaction.payment.productIdentifier, @"productId",
                                              [receiptData base64EncodedStringWithOptions:0], @"transactionReceipt",
+                                             [NSNumber numberWithInt: transaction.transactionState], @"transactionStateIOS",
                                              nil
                                              ];
             

--- a/lib/modules.dart
+++ b/lib/modules.dart
@@ -116,6 +116,7 @@ class PurchasedItem {
   // iOS only
   final DateTime originalTransactionDateIOS;
   final String originalTransactionIdentifierIOS;
+  final TransactionState transactionStateIOS;
 
   /// Create [PurchasedItem] from a Map that was previously JSON formatted
   PurchasedItem.fromJSON(Map<String, dynamic> json)
@@ -137,7 +138,9 @@ class PurchasedItem {
         originalTransactionDateIOS =
             _extractDate(json['originalTransactionDateIOS']),
         originalTransactionIdentifierIOS =
-            json['originalTransactionIdentifierIOS'] as String;
+            json['originalTransactionIdentifierIOS'] as String,
+        transactionStateIOS =
+            _decodeTransactionStateIOS(json['transactionStateIOS'] as int);
 
   /// This returns transaction dates in ISO 8601 format.
   @override
@@ -158,7 +161,8 @@ class PurchasedItem {
         'originalJsonAndroid: $originalJsonAndroid, '
         /// ios specific
         'originalTransactionDateIOS: ${originalTransactionDateIOS?.toIso8601String()}, '
-        'originalTransactionIdentifierIOS: $originalTransactionIdentifierIOS';
+        'originalTransactionIdentifierIOS: $originalTransactionIdentifierIOS, '
+        'transactionStateIOS: $transactionStateIOS';
   }
 
   /// Coerce miliseconds since epoch in double, int, or String into DateTime format
@@ -225,5 +229,40 @@ class ConnectionResult {
   String toString() {
     return 'connected: $connected'
     ;
+  }
+}
+
+/// See also https://developer.apple.com/documentation/storekit/skpaymenttransactionstate
+enum TransactionState {
+  /// A transaction that is being processed by the App Store.
+  purchasing,
+
+  /// A successfully processed transaction.
+  purchased,
+
+  /// A failed transaction.
+  failed,
+
+  /// A transaction that restores content previously purchased by the user.
+  restored,
+
+  /// A transaction that is in the queue, but its final status is pending external action such as Ask to Buy.
+  deferred,
+}
+
+TransactionState _decodeTransactionStateIOS(int rawValue) {
+  switch (rawValue) {
+    case 0:
+      return TransactionState.purchasing;
+    case 1:
+      return TransactionState.purchased;
+    case 2:
+      return TransactionState.failed;
+    case 3:
+      return TransactionState.restored;
+    case 4:
+      return TransactionState.deferred;
+    default:
+      return null;
   }
 }


### PR DESCRIPTION
* This PR adds `transactionStateIOS` to `PurchasedItem`.
* It is valid only in iOS and always null in Android.
* It does not break existing code.

## Reason

To avoid [This In-App Purchase has aready been bought](https://www.greensopinion.com/2017/03/22/This-In-App-Purchase-Has-Already-Been-Bought.html) dialog, I'm implementing recovery logic from incomplete in-app purchase at app startup time. This is like:

```dart
Future<void> processPendingTransactions() async {
    final transactions = await FlutterInappPurchase.instance.getPendingTransactionsIOS();
    if (tTransactions == null) {
        return;
    }
    for (final t in transactions) {
        await sendReceiptToServerAndVerify(t);
        await FlutterInappPurchase.instance.finishTransactionIOS(t.transactionId);
    }
}
```

In above code, `transactions` may have a transaction that is canceled by user. This occurs by following steps:

1. Call `FlutterInappPurchase.requestSubscription(sku)`
2. Press home button to go to home screen.
3. In-App purchase dialog appears on home screen (app is in background)
4. Cancel In-App dialog.
5. Kill app from task list.
6. Restart app.

I want to check transaction state before send receipt to server. In above code:

```dart
Future<void> processPendingTransactions() async {
    final transactions = await FlutterInappPurchase.instance.getPendingTransactionsIOS();
    if (tTransactions == null) {
        return;
    }
    for (final t in transactions) {
        if (t.transactionStateIOS == TransactionState.purchased) { // <- I want to add this
            await sendReceiptToServerAndVerify(t);
        }
        await FlutterInappPurchase.instance.finishTransactionIOS(t.transactionId);
    }
}
```
