### PR TITLE
Set defaults for finishing transaction

### DIFF
--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -423,7 +423,7 @@ class FlutterInappPurchase {
   ///
   /// Call this after finalizing server-side validation of the reciept.
   Future<String> finishTransaction(PurchasedItem purchasedItem,
-    { String developerPayloadAndroid, bool isConsumable }) async {
+    { String developerPayloadAndroid = '', bool isConsumable = false }) async {
     if (_platform.isAndroid) {
       if (isConsumable) {
         String result = await _channel.invokeMethod('consumeProduct', <String, dynamic>{


### PR DESCRIPTION
When testing on Android BETA we got the message: "Boolean expression must not be null". I spent ages figuring this out, so thought it would be good to have some sensible defaults here so others avoid this message :-)