### PR TITLE
Finish failed transaction in iOS

### DIFF
--- a/ios/Classes/FlutterInappPurchasePlugin.m
+++ b/ios/Classes/FlutterInappPurchasePlugin.m
@@ -537,6 +537,7 @@
                 NSLog(@"Deferred (awaiting approval via parental controls, etc.)");
                 break;
             case SKPaymentTransactionStateFailed:
+                [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
                 [requestedPayments removeObjectForKey:transaction.payment];
                 NSDictionary *err = [NSDictionary dictionaryWithObjectsAndKeys:
                                      @"SKPaymentTransactionStateFailed", @"debugMessage",


### PR DESCRIPTION
This was not the issue and worked fine prior to the iOS 13.4 
[The official documentation](https://developer.apple.com/documentation/storekit/skpaymentqueue/1506003-finishtransaction) doesn't clearly state what states of a transaction must be finished but looks like for iOS 13.4+ this is crucial to finish failed transactions. Otherwise, users are getting back over and over the last unfinished transaction, in this case, it is usually a failed one.

[Here is a link](https://forums.developer.apple.com/thread/130793) to the relevant discussion on apple forums. 