### PR TITLE
The dart side requires "introductoryPriceCyclesAndroid" to be a int

### DIFF
--- a/android/src/main/java/com/dooboolab/flutterinapppurchase/AmazonInappPurchasePlugin.java
+++ b/android/src/main/java/com/dooboolab/flutterinapppurchase/AmazonInappPurchasePlugin.java
@@ -180,7 +180,7 @@ public class AmazonInappPurchasePlugin implements MethodCallHandler {
               item.put("introductoryPrice", "");
               item.put("subscriptionPeriodAndroid", "");
               item.put("freeTrialPeriodAndroid", "");
-              item.put("introductoryPriceCyclesAndroid", "");
+              item.put("introductoryPriceCyclesAndroid", 0);
               item.put("introductoryPricePeriodAndroid", "");
               Log.d(TAG, "opdr Putting "+item.toString());
               items.put(item);


### PR DESCRIPTION
This bugs causes crashes when using the Amazon App Store.  It looks like the value is not used by Amazon, however, the default value on the Java side was set to a String, but the dart side requires the value to be an int.