### PR TITLE
Support for Amazon devices with Google Play sideloaded

### DIFF
--- a/android/src/main/java/com/dooboolab/flutterinapppurchase/FlutterInappPurchasePlugin.java
+++ b/android/src/main/java/com/dooboolab/flutterinapppurchase/FlutterInappPurchasePlugin.java
@@ -56,9 +56,7 @@ public class FlutterInappPurchasePlugin implements FlutterPlugin, ActivityAware 
 
   @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-    if (isAndroid) {
-      tearDownChannel();
-    } else if(isAmazon) {
+    if (isAndroid || isAmazon) {
       tearDownChannel();
     }
   }

--- a/android/src/main/java/com/dooboolab/flutterinapppurchase/FlutterInappPurchasePlugin.java
+++ b/android/src/main/java/com/dooboolab/flutterinapppurchase/FlutterInappPurchasePlugin.java
@@ -30,6 +30,16 @@ public class FlutterInappPurchasePlugin implements FlutterPlugin, ActivityAware 
     isAndroid = isPackageInstalled(context, "com.android.vending");
     isAmazon = isPackageInstalled(context, "com.amazon.venezia");
 
+    // In the case of an amazon device which has been side loaded with the Google Play store,
+    // we should use the store the app was installed from.
+    if (isAmazon && isAndroid) {
+      if (isAppInstalledFrom(context, "amazon")) {
+        isAndroid = false;
+      } else {
+        isAmazon = false;
+      }
+    }
+
     if (isAndroid) {
       androidInappPurchasePlugin = new AndroidInappPurchasePlugin();
       androidInappPurchasePlugin.setContext(context);
@@ -46,9 +56,9 @@ public class FlutterInappPurchasePlugin implements FlutterPlugin, ActivityAware 
 
   @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-    if (isPackageInstalled(context, "com.android.vending")) {
+    if (isAndroid) {
       tearDownChannel();
-    } else if(isPackageInstalled(context, "com.amazon.venezia")) {
+    } else if(isAmazon) {
       tearDownChannel();
     }
   }
@@ -75,19 +85,19 @@ public class FlutterInappPurchasePlugin implements FlutterPlugin, ActivityAware 
 
   @Override
   public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
-    if (isPackageInstalled(context, "com.android.vending")) {
+    if (isAndroid) {
       androidInappPurchasePlugin.setActivity(binding.getActivity());
-    } else if(isPackageInstalled(context, "com.amazon.venezia")) {
+    } else if(isAmazon) {
       amazonInappPurchasePlugin.setActivity(binding.getActivity());
     }
   }
 
   @Override
   public void onDetachedFromActivity() {
-    if (isPackageInstalled(context, "com.android.vending")) {
+    if (isAndroid) {
       androidInappPurchasePlugin.setActivity(null);
       androidInappPurchasePlugin.onDetachedFromActivity();
-    } else if(isPackageInstalled(context, "com.amazon.venezia")) {
+    } else if(isAmazon) {
       amazonInappPurchasePlugin.setActivity(null);
     }
   }
@@ -109,6 +119,15 @@ public class FlutterInappPurchasePlugin implements FlutterPlugin, ActivityAware 
       return false;
     }
     return true;
+  }
+
+  public static final boolean isAppInstalledFrom(Context ctx, String installer) {
+    String installerPackageName = ctx.getPackageManager().getInstallerPackageName(
+            ctx.getPackageName());
+    if (installer != null && installerPackageName.contains(installer)){
+      return true;
+    }
+    return false;
   }
 
   private void setupMethodChannel(BinaryMessenger messenger, MethodChannel.MethodCallHandler handler) {

--- a/android/src/main/java/com/dooboolab/flutterinapppurchase/FlutterInappPurchasePlugin.java
+++ b/android/src/main/java/com/dooboolab/flutterinapppurchase/FlutterInappPurchasePlugin.java
@@ -124,7 +124,7 @@ public class FlutterInappPurchasePlugin implements FlutterPlugin, ActivityAware 
   public static final boolean isAppInstalledFrom(Context ctx, String installer) {
     String installerPackageName = ctx.getPackageManager().getInstallerPackageName(
             ctx.getPackageName());
-    if (installer != null && installerPackageName.contains(installer)){
+    if (installer != null && installerPackageName != null && installerPackageName.contains(installer)){
       return true;
     }
     return false;


### PR DESCRIPTION
When the google play store is sideloaded onto an amazon device, it isn't good enough to just check for the presence of the app store. Instead, the store used has to be the store the app was installed from.

This adds support for this in cases where both the Google Play store and the Amazon app store are installed.