### PR TITLE
Use http client in validateReceiptIos

### DIFF
--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -53,7 +53,7 @@ class FlutterInappPurchase {
   @visibleForTesting
   FlutterInappPurchase.private(Platform platform, {http.Client? client})
       : _pf = platform,
-        _httpClient = client;
+        _httpClient = client ?? http.Client();
 
   /// Returns the platform version on `Android` and `iOS`.
   ///
@@ -549,7 +549,7 @@ class FlutterInappPurchase {
     final String url = isTest
         ? 'https://sandbox.itunes.apple.com/verifyReceipt'
         : 'https://buy.itunes.apple.com/verifyReceipt';
-    return await http.post(
+    return await _client!.post(
       Uri.parse(url),
       headers: {
         'Accept': 'application/json',

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -40,10 +40,10 @@ class FlutterInappPurchase {
   static MethodChannel get channel => _channel;
 
   final Platform _pf;
-  final http.Client? _httpClient;
+  late http.Client _httpClient;
 
   static Platform get _platform => instance._pf;
-  static http.Client? get _client => instance._httpClient;
+  static http.Client get _client => instance._httpClient;
 
   factory FlutterInappPurchase(FlutterInappPurchase _instance) {
     instance = _instance;
@@ -549,7 +549,7 @@ class FlutterInappPurchase {
     final String url = isTest
         ? 'https://sandbox.itunes.apple.com/verifyReceipt'
         : 'https://buy.itunes.apple.com/verifyReceipt';
-    return await _client!.post(
+    return await _client.post(
       Uri.parse(url),
       headers: {
         'Accept': 'application/json',
@@ -585,7 +585,7 @@ class FlutterInappPurchase {
     final String type = isSubscription ? 'subscriptions' : 'products';
     final String url =
         'https://www.googleapis.com/androidpublisher/v3/applications/$packageName/purchases/$type/$productId/tokens/$productToken?access_token=$accessToken';
-    return await _client!.get(
+    return await _client.get(
       Uri.parse(url),
       headers: {
         'Accept': 'application/json',

--- a/test/flutter_inapp_purchase_test.dart
+++ b/test/flutter_inapp_purchase_test.dart
@@ -1400,7 +1400,7 @@ void main() {
         });
 
         FlutterInappPurchase(FlutterInappPurchase.private(
-            FakePlatform(operatingSystem: "ios"),
+            FakePlatform(operatingSystem: "android"),
             client: mockClient));
       });
 
@@ -1441,6 +1441,58 @@ void main() {
                 isSubscription: false);
         expect(response.request!.url.toString(),
             "https://www.googleapis.com/androidpublisher/v3/applications/$packageName/purchases/$type/$productId/tokens/$productToken?access_token=$accessToken");
+      });
+    });
+
+    group('validateReceiptIos', () {
+      final receiptBody = {
+        'receipt-data': 'purchasedItem.transactionReceipt',
+        'password': 'apple_password'
+      };
+
+      setUp(() {
+        http.Client mockClient = MockClient((request) async {
+          return Response(json.encode({'status': 0}), 200);
+        });
+
+        FlutterInappPurchase(FlutterInappPurchase.private(
+          FakePlatform(operatingSystem: "ios"),
+          client: mockClient,
+        ));
+      });
+
+      tearDown(() {
+        FlutterInappPurchase.channel.setMethodCallHandler(null);
+      });
+
+      test('returns correct http request url in sandbox', () async {
+        final response = await FlutterInappPurchase.instance.validateReceiptIos(
+          receiptBody: receiptBody,
+          isTest: true,
+        );
+
+        expect(
+          response.request!.url.toString(),
+          "https://sandbox.itunes.apple.com/verifyReceipt",
+        );
+        expect(response.statusCode, 200);
+        final data = jsonDecode(response.body);
+        expect(data['status'], 0);
+      });
+
+      test('returns correct http request url in production', () async {
+        final response = await FlutterInappPurchase.instance.validateReceiptIos(
+          receiptBody: receiptBody,
+          isTest: false,
+        );
+
+        expect(
+          response.request!.url.toString(),
+          "https://buy.itunes.apple.com/verifyReceipt",
+        );
+        expect(response.statusCode, 200);
+        final data = jsonDecode(response.body);
+        expect(data['status'], 0);
       });
     });
   });


### PR DESCRIPTION
The `validateReceiptIos` function uses the `http` library directly instead of the `_client` instance.

https://github.com/dooboolab/flutter_inapp_purchase/blob/24b290cff01d99494e7a38fb27373027acf8cd07/lib/flutter_inapp_purchase.dart#L552-L560

And the `validateReceiptAndroid` function uses the `_client` instance.

https://github.com/dooboolab/flutter_inapp_purchase/blob/24b290cff01d99494e7a38fb27373027acf8cd07/lib/flutter_inapp_purchase.dart#L588-L594

I think using the `_client` is reasonable because we can use it for testing by assigning the mock client.

```dart
final client = MockClient();

FlutterInappPurchase(FlutterInappPurchase.private(
  FakePlatform(operatingSystem: 'ios'),
  client: client,
));
```

So, I changed `http` to `_client` and initialize it.