### PR TITLE
Run on UiThread and few others

### DIFF
--- a/android/src/main/java/com/dooboolab/flutterinapppurchase/MethodResultWrapper.java
+++ b/android/src/main/java/com/dooboolab/flutterinapppurchase/MethodResultWrapper.java
@@ -1,0 +1,63 @@
+package com.dooboolab.flutterinapppurchase;
+
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.MethodChannel.Result;
+
+import android.os.Handler;
+import android.os.Looper;
+
+// MethodChannel.Result wrapper that responds on the platform thread.
+public class MethodResultWrapper implements Result {
+  private Result safeResult;
+  private MethodChannel safeChannel;
+  private Handler handler;
+
+  MethodResultWrapper(Result result, MethodChannel channel) {
+    safeResult = result;
+    safeChannel = channel;
+    handler = new Handler(Looper.getMainLooper());
+  }
+
+  @Override
+  public void success(final Object result) {
+    handler.post(
+      new Runnable() {
+        @Override
+        public void run() {
+          safeResult.success(result);
+        }
+      });
+  }
+
+  @Override
+  public void error(final String errorCode, final String errorMessage, final Object errorDetails) {
+    handler.post(
+      new Runnable() {
+        @Override
+        public void run() {
+          safeResult.error(errorCode, errorMessage, errorDetails);
+        }
+      });
+  }
+
+  @Override
+  public void notImplemented() {
+    handler.post(
+      new Runnable() {
+        @Override
+        public void run() {
+          safeResult.notImplemented();
+        }
+      });
+  }
+
+  public void invokeMethod(final String method, final Object arguments) {
+    handler.post(
+      new Runnable() {
+        @Override
+        public void run() {
+          safeChannel.invokeMethod(method, arguments, null);
+        }
+      });
+  }
+}

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -17,23 +17,28 @@ export 'modules.dart';
 enum _TypeInApp { inapp, subs }
 
 class FlutterInappPurchase {
-  static FlutterInappPurchase instance = FlutterInappPurchase(FlutterInappPurchase.private(const LocalPlatform()));
+  static FlutterInappPurchase instance =
+      FlutterInappPurchase(FlutterInappPurchase.private(const LocalPlatform()));
 
   static StreamController<PurchasedItem?>? _purchaseController;
 
-  static Stream<PurchasedItem?> get purchaseUpdated => _purchaseController!.stream;
+  static Stream<PurchasedItem?> get purchaseUpdated =>
+      _purchaseController!.stream;
 
   static StreamController<PurchaseResult?>? _purchaseErrorController;
 
-  static Stream<PurchaseResult?> get purchaseError => _purchaseErrorController!.stream;
+  static Stream<PurchaseResult?> get purchaseError =>
+      _purchaseErrorController!.stream;
 
   static StreamController<ConnectionResult>? _connectionController;
 
-  static Stream<ConnectionResult> get connectionUpdated => _connectionController!.stream;
+  static Stream<ConnectionResult> get connectionUpdated =>
+      _connectionController!.stream;
 
   static StreamController<String?>? _purchasePromotedController;
 
-  static Stream<String?> get purchasePromoted => _purchasePromotedController!.stream;
+  static Stream<String?> get purchasePromoted =>
+      _purchasePromotedController!.stream;
 
   /// Defining the [MethodChannel] for Flutter_Inapp_Purchase
   static final MethodChannel _channel = const MethodChannel('flutter_inapp');
@@ -60,7 +65,8 @@ class FlutterInappPurchase {
   /// Returns the platform version on `Android` and `iOS`.
   ///
   /// eg, `Android 5.1.1`
-  Future<String?> get platformVersion async => await _channel.invokeMethod('getPlatformVersion');
+  Future<String?> get platformVersion async =>
+      await _channel.invokeMethod('getPlatformVersion');
 
   /// Consumes all items on `Android`.
   ///
@@ -77,7 +83,8 @@ class FlutterInappPurchase {
     } else if (_platform.isIOS) {
       return 'no-ops in ios';
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 
   /// InitConnection prepare iap features for both `Android` and `iOS`.
@@ -99,7 +106,8 @@ class FlutterInappPurchase {
       await _setPurchaseListener();
       return await _channel.invokeMethod('canMakePayments');
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 
   /// Retrieves a list of products from the store on `Android` and `iOS`.
@@ -124,7 +132,8 @@ class FlutterInappPurchase {
       );
       return extractItems(json.encode(result));
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 
   /// Retrieves subscriptions on `Android` and `iOS`.
@@ -149,7 +158,8 @@ class FlutterInappPurchase {
       );
       return extractItems(json.encode(result));
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 
   /// Retrieves the user's purchase history on `Android` and `iOS` regardless of consumption status.
@@ -172,15 +182,18 @@ class FlutterInappPurchase {
         },
       );
 
-      List<dynamic> results = await Future.wait([getInappPurchaseHistory, getSubsPurchaseHistory]);
+      List<dynamic> results =
+          await Future.wait([getInappPurchaseHistory, getSubsPurchaseHistory]);
 
-      return results.reduce((result1, result2) => extractPurchased(result1)! + extractPurchased(result2)!);
+      return results.reduce((result1, result2) =>
+          extractPurchased(result1)! + extractPurchased(result2)!);
     } else if (_platform.isIOS) {
       dynamic result = await _channel.invokeMethod('getAvailableItems');
 
       return extractPurchased(json.encode(result));
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 
   /// Get all non-consumed purchases made on `Android` and `iOS`.
@@ -208,7 +221,8 @@ class FlutterInappPurchase {
 
       return extractPurchased(json.encode(result));
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 
   /// Request a purchase on `Android` or `iOS`.
@@ -238,7 +252,8 @@ class FlutterInappPurchase {
         'forUser': obfuscatedAccountId,
       });
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 
   /// Request a subscription on `Android` or `iOS`.
@@ -271,7 +286,8 @@ class FlutterInappPurchase {
         'sku': sku,
       });
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 
   /// Add Store Payment (iOS only)
@@ -293,7 +309,8 @@ class FlutterInappPurchase {
     if (_platform.isIOS) {
       return await _channel.invokeMethod('requestPromotedProduct');
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 
   /// Buy product with offer
@@ -305,13 +322,15 @@ class FlutterInappPurchase {
     Map<String, dynamic> withOffer,
   ) async {
     if (_platform.isIOS) {
-      return await _channel.invokeMethod('requestProductWithOfferIOS', <String, dynamic>{
+      return await _channel
+          .invokeMethod('requestProductWithOfferIOS', <String, dynamic>{
         'sku': sku,
         'forUser': forUser,
         'withOffer': withOffer,
       });
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 
   /// Buy product with quantity
@@ -322,12 +341,14 @@ class FlutterInappPurchase {
     int quantity,
   ) async {
     if (_platform.isIOS) {
-      return await _channel.invokeMethod('requestProductWithQuantityIOS', <String, dynamic>{
+      return await _channel
+          .invokeMethod('requestProductWithQuantityIOS', <String, dynamic>{
         'sku': sku,
         'quantity': quantity.toString(),
       });
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 
   /// Get the pending purchases in IOS.
@@ -349,13 +370,15 @@ class FlutterInappPurchase {
   /// No effect on `iOS`, whose iap purchases are consumed at the time of purchase.
   Future<String?> acknowledgePurchaseAndroid(String token) async {
     if (_platform.isAndroid) {
-      return await _channel.invokeMethod('acknowledgePurchase', <String, dynamic>{
+      return await _channel
+          .invokeMethod('acknowledgePurchase', <String, dynamic>{
         'token': token,
       });
     } else if (_platform.isIOS) {
       return 'no-ops in ios';
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 
   /// Consumes a purchase on `Android`.
@@ -378,7 +401,8 @@ class FlutterInappPurchase {
     } else if (_platform.isIOS) {
       return 'no-ops in ios';
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 
   /// End Play Store connection on `Android` and remove iap observer in `iOS`.
@@ -400,7 +424,8 @@ class FlutterInappPurchase {
       _removePurchaseListener();
       return result;
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 
   /// Finish a transaction on `iOS`.
@@ -416,20 +441,23 @@ class FlutterInappPurchase {
         'transactionIdentifier': transactionId,
       });
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 
   /// Finish a transaction on both `android` and `iOS`.
   ///
   /// Call this after finalizing server-side validation of the reciept.
-  Future<String?> finishTransaction(PurchasedItem purchasedItem, {bool isConsumable = false}) async {
+  Future<String?> finishTransaction(PurchasedItem purchasedItem,
+      {bool isConsumable = false}) async {
     if (_platform.isAndroid) {
       if (isConsumable) {
         return await _channel.invokeMethod('consumeProduct', <String, dynamic>{
           'token': purchasedItem.purchaseToken,
         });
       } else {
-        return await _channel.invokeMethod('acknowledgePurchase', <String, dynamic>{
+        return await _channel
+            .invokeMethod('acknowledgePurchase', <String, dynamic>{
           'token': purchasedItem.purchaseToken,
         });
       }
@@ -438,7 +466,8 @@ class FlutterInappPurchase {
         'transactionIdentifier': purchasedItem.transactionId,
       });
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 
   /// Clear all remaining transaction on `iOS`.
@@ -450,7 +479,8 @@ class FlutterInappPurchase {
     } else if (_platform.isIOS) {
       return await _channel.invokeMethod('clearTransaction');
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 
   /// Retrieves a list of products that have been attempted to purchase through the App Store `iOS` only.
@@ -459,11 +489,13 @@ class FlutterInappPurchase {
     if (_platform.isAndroid) {
       return <IAPItem>[];
     } else if (_platform.isIOS) {
-      dynamic result = await _channel.invokeMethod('getAppStoreInitiatedProducts');
+      dynamic result =
+          await _channel.invokeMethod('getAppStoreInitiatedProducts');
 
       return extractItems(json.encode(result));
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 
   /// Check if a subscription is active on `Android` and `iOS`.
@@ -477,16 +509,20 @@ class FlutterInappPurchase {
     Duration grace: const Duration(days: 3),
   }) async {
     if (_platform.isIOS) {
-      var history = await (getPurchaseHistory() as FutureOr<List<PurchasedItem>>);
+      var history =
+          await (getPurchaseHistory() as FutureOr<List<PurchasedItem>>);
 
       for (var purchase in history) {
-        Duration difference = DateTime.now().difference(purchase.transactionDate!);
-        if (difference.inMinutes <= (duration + grace).inMinutes && purchase.productId == sku) return true;
+        Duration difference =
+            DateTime.now().difference(purchase.transactionDate!);
+        if (difference.inMinutes <= (duration + grace).inMinutes &&
+            purchase.productId == sku) return true;
       }
 
       return false;
     } else if (_platform.isAndroid) {
-      var purchases = await (getAvailablePurchases() as FutureOr<List<PurchasedItem>>);
+      var purchases =
+          await (getAvailablePurchases() as FutureOr<List<PurchasedItem>>);
 
       for (var purchase in purchases) {
         if (purchase.productId == sku) return true;
@@ -494,7 +530,8 @@ class FlutterInappPurchase {
 
       return false;
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 
   /// Validate receipt in ios
@@ -512,7 +549,9 @@ class FlutterInappPurchase {
     required Map<String, String> receiptBody,
     bool isTest = true,
   }) async {
-    final String url = isTest ? 'https://sandbox.itunes.apple.com/verifyReceipt' : 'https://buy.itunes.apple.com/verifyReceipt';
+    final String url = isTest
+        ? 'https://sandbox.itunes.apple.com/verifyReceipt'
+        : 'https://buy.itunes.apple.com/verifyReceipt';
     return await _client.post(
       Uri.parse(url),
       headers: {
@@ -547,7 +586,8 @@ class FlutterInappPurchase {
     bool isSubscription = false,
   }) async {
     final String type = isSubscription ? 'subscriptions' : 'products';
-    final String url = 'https://www.googleapis.com/androidpublisher/v3/applications/$packageName/purchases/$type/$productId/tokens/$productToken?access_token=$accessToken';
+    final String url =
+        'https://www.googleapis.com/androidpublisher/v3/applications/$packageName/purchases/$type/$productId/tokens/$productToken?access_token=$accessToken';
     return await _client.get(
       Uri.parse(url),
       headers: {
@@ -603,7 +643,8 @@ class FlutterInappPurchase {
     if (_platform.isIOS) {
       return await _channel.invokeMethod('showRedeemCodesIOS');
     }
-    throw PlatformException(code: _platform.operatingSystem, message: "platform not supported");
+    throw PlatformException(
+        code: _platform.operatingSystem, message: "platform not supported");
   }
 }
 

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -35,13 +35,3 @@ List<PurchaseResult>? extractResult(dynamic result) {
 
   return decoded;
 }
-
-class EnumUtil {
-  /// return enum value
-  ///
-  /// example: enum Type {Hoge},
-  /// String value = EnumUtil.getValueString(Type.Hoge);
-  /// assert(value == "Hoge");
-  static String getValueString(dynamic enumType) =>
-      enumType.toString().split('.')[1];
-}

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_inapp_purchase/utils.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 enum _TestEnum { Hoge }
@@ -6,7 +6,7 @@ enum _TestEnum { Hoge }
 void main() {
   group('utils', () {
     test('EnumUtil.getValueString', () async {
-      String value = EnumUtil.getValueString(_TestEnum.Hoge);
+      String value = describeEnum(_TestEnum.Hoge);
       expect(value, "Hoge");
     });
   });


### PR DESCRIPTION
With reference to https://github.com/dooboolab/flutter_inapp_purchase/issues/272

So, a few words about the changes. First of all, sorry about some whitespace differences but, apparently, our IDEs use _dartformat_ with slightly different settings.

The main difference is a new `MethodResultWrapper` class that wraps both the _result_ and the _channel_. `onMethodCall()` now immediately saves this wrapped result-channel to a field and only uses that later to set both the result and to send back info on the channel. I did this in both Google and Amazon but I can't test the Amazon one.

Second, I included the plugin registration differences I suggested in the issue queue above.

Third, I did the modification suggested in one of the issues (I can't find it right now to link it, sorry) that `initConnection`, `endConnection` and `consumeAllItems` shouldn't be accessors. This is very much so, property accessors are not supposed to do work and have side effects, just return a value. I suggested now three new functions and marked the old ones deprecated, so you could safely leave it as is for some time, maybe until the next major version, if you accept the suggestion.

Fourth, `EnumUtil.getValueString()` is not really necessary, we have `describeEnum()` in the Flutter engine just for this purpose.