### PR TITLE
Fix IllegalStateException in getPurchaseHistory for Android 

### DIFF
--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -168,22 +168,21 @@ class FlutterInappPurchase {
   /// Identical to [getAvailablePurchases] on `iOS`.
   Future<List<PurchasedItem>?> getPurchaseHistory() async {
     if (_platform.isAndroid) {
-      Future<dynamic> getInappPurchaseHistory = _channel.invokeMethod(
+      dynamic getInappPurchaseHistory = await _channel.invokeMethod(
         'getPurchaseHistoryByType',
         <String, dynamic>{
           'type': describeEnum(_TypeInApp.inapp),
         },
       );
 
-      Future<dynamic> getSubsPurchaseHistory = _channel.invokeMethod(
+      dynamic getSubsPurchaseHistory = await _channel.invokeMethod(
         'getPurchaseHistoryByType',
         <String, dynamic>{
           'type': describeEnum(_TypeInApp.subs),
         },
       );
 
-      List<dynamic> results =
-          await Future.wait([getInappPurchaseHistory, getSubsPurchaseHistory]);
+      List<dynamic> results = [getInappPurchaseHistory, getSubsPurchaseHistory];
 
       return results.reduce((result1, result2) =>
           extractPurchased(result1)! + extractPurchased(result2)!);


### PR DESCRIPTION
The method getPurchaseHistory raises an IllegalStateException: Reply already submitted in Android
I am not sure if this is the best way to fix the issue because it makes the function slower, but at least the exception isn't thrown anymore

java.lang.IllegalStateException: Reply already submitted
at io.flutter.embedding.engine.dart.DartMessenger$Reply.reply(DartMessenger.java:164)
at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler$1.success(MethodChannel.java:238)
at com.dooboolab.flutterinapppurchase.MethodResultWrapper$1.run(MethodResultWrapper.java:27)
at android.os.Handler.handleCallback(Handler.java:938)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loopOnce(Looper.java:201)
at android.os.Looper.loop(Looper.java:288)
at android.app.ActivityThread.main(ActivityThread.java:7838)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
