### PR TITLE
Fixed wrong casting in checkSubscribed method

### DIFF
--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -542,8 +542,12 @@ class FlutterInappPurchase {
   }) async {
     if (_platform.isIOS) {
       var history =
-          await (getPurchaseHistory() as FutureOr<List<PurchasedItem>>);
+          await (getPurchaseHistory() as Future<List<PurchasedItem>?>);
 
+      if (history == null) {
+        return false;
+      }      
+      
       for (var purchase in history) {
         Duration difference =
             DateTime.now().difference(purchase.transactionDate!);

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -541,7 +541,8 @@ class FlutterInappPurchase {
     Duration grace = const Duration(days: 3),
   }) async {
     if (_platform.isIOS) {
-      var history = await (getPurchaseHistory() as Future<List<PurchasedItem>?>);
+      var history =
+          await (getPurchaseHistory() as Future<List<PurchasedItem>?>);
 
       if (history == null) {
         return false;

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -541,13 +541,12 @@ class FlutterInappPurchase {
     Duration grace = const Duration(days: 3),
   }) async {
     if (_platform.isIOS) {
-      var history =
-          await (getPurchaseHistory() as Future<List<PurchasedItem>?>);
+      var history = await (getPurchaseHistory() as Future<List<PurchasedItem>?>);
 
       if (history == null) {
         return false;
-      }      
-      
+      }
+
       for (var purchase in history) {
         Duration difference =
             DateTime.now().difference(purchase.transactionDate!);


### PR DESCRIPTION
secures 

```
flutter: type 'Future<List<PurchasedItem>?>' is not a subtype of type 'FutureOr<List<PurchasedItem>>' in type cast
flutter: 
#0      FlutterInappPurchase.checkSubscribed (package:flutter_inapp_purchase/flutter_inapp_purchase.dart:509:39)
```

under Flutter version 2.10.5