### PR TITLE
Import com.amazon.device:amazon-appstore-sdk 3.0.3 from MAVEN instead of static files

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,7 +45,7 @@ android {
 
 dependencies {
     implementation 'com.android.billingclient:billing-ktx:4.1.0'
-    implementation files('jars/in-app-purchasing-2.0.76.jar')
+    implementation 'com.amazon.device:amazon-appstore-sdk:3.0.3'
     implementation 'androidx.annotation:annotation:1.3.0'
 }
 


### PR DESCRIPTION
I'm not an Android developer, but I was having issues because of the OLD lib version 2.0.76. So, based on this issue #380, I'm creating a PR just to change the import without any test.

I did it here to compile my code, but can be a head-start to others.
(or even a final fix)

Let me know if there is anything else that could improve it and I will be happy to change and update.