### PR TITLE
Upgrade to billing 5.1 (reverse compatible)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,8 +44,8 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.billingclient:billing-ktx:4.1.0'
+    implementation 'com.android.billingclient:billing-ktx:5.0.0'
     implementation files('jars/in-app-purchasing-2.0.76.jar')
-    implementation 'androidx.annotation:annotation:1.3.0'
+    implementation 'androidx.annotation:annotation:1.4.0'
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.billingclient:billing:5.0.0'
+    implementation 'com.android.billingclient:billing:5.1.0'
     implementation files('jars/in-app-purchasing-2.0.76.jar')
     implementation 'androidx.annotation:annotation:1.4.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.billingclient:billing-ktx:5.0.0'
+    implementation 'com.android.billingclient:billing:5.0.0'
     implementation files('jars/in-app-purchasing-2.0.76.jar')
     implementation 'androidx.annotation:annotation:1.4.0'
 }

--- a/android/src/main/kotlin/com/dooboolab/flutterinapppurchase/AndroidInappPurchasePlugin.kt
+++ b/android/src/main/kotlin/com/dooboolab/flutterinapppurchase/AndroidInappPurchasePlugin.kt
@@ -423,16 +423,22 @@ class AndroidInappPurchasePlugin internal constructor() : MethodCallHandler,
                     item.put("title", productDetails.title)
                     item.put("description", productDetails.description)
 
+                    // One-time offer details have changed in 5.0
+                    if (productDetails.oneTimePurchaseOfferDetails != null) {
+                        item.put("introductoryPrice", productDetails.oneTimePurchaseOfferDetails!!.formattedPrice)
+                    }
+
                     // These generalized values are derived from the first pricing object, mainly for backwards compatibility
                     // It would be better to use the actual objects in PricingPhases and SubscriptionOffers
 
                     // Get first subscription offer
-                    val firstProductInfo = productDetails.subscriptionOfferDetails?.get(0)
+                    val firstProductInfo = productDetails.subscriptionOfferDetails?.find { offer -> offer.offerId == null }
                     if (firstProductInfo != null && firstProductInfo.pricingPhases.pricingPhaseList[0] != null) {
                         val defaultPricingPhase = firstProductInfo.pricingPhases.pricingPhaseList[0]
                         item.put("price", (defaultPricingPhase.priceAmountMicros / 1000000f).toString())
                         item.put("currency", defaultPricingPhase.priceCurrencyCode)
                         item.put("localizedPrice", defaultPricingPhase.formattedPrice)
+                        item.put("subscriptionPeriodAndroid", defaultPricingPhase.billingPeriod)
                     }
 
                     val subs = JSONArray()

--- a/android/src/main/kotlin/com/dooboolab/flutterinapppurchase/AndroidInappPurchasePlugin.kt
+++ b/android/src/main/kotlin/com/dooboolab/flutterinapppurchase/AndroidInappPurchasePlugin.kt
@@ -430,7 +430,7 @@ class AndroidInappPurchasePlugin internal constructor() : MethodCallHandler,
                             for (pricing in it.pricingPhases.pricingPhaseList) {
                                 val subItem = JSONObject()
                                 subItem.put("introductoryPrice", pricing.formattedPrice)
-                                subItem.put("subscriptionPeriodAndroid", pricing.billingPeriod.)
+                                subItem.put("subscriptionPeriodAndroid", pricing.billingPeriod)
 //                                item.put("freeTrialPeriodAndroid", pricing.getRecurrenceMode())
                                 subItem.put("introductoryPriceCyclesAndroid", pricing.billingCycleCount)
 //                                item.put("introductoryPricePeriodAndroid", pricing.p)
@@ -439,9 +439,6 @@ class AndroidInappPurchasePlugin internal constructor() : MethodCallHandler,
 
                         }
                     }
-                    // new
-//                    item.put("iconUrl", skuDetails.)
-//                    item.put("originalJson", skuDetails.zzb)
                     item.put("subscriptionOfferDetails", subs)
                     item.put("originalPrice", ((skuDetails.oneTimePurchaseOfferDetails?.priceAmountMicros ?: 0) / 1000000f).toDouble())
                     items.put(item)

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -147,12 +147,12 @@ class FlutterInappPurchase {
   /// Retrieves a list of products from the store on `Android` and `iOS`.
   ///
   /// `iOS` also returns subscriptions.
-  Future<List<IAPItem>> getProducts(List<String> skus) async {
+  Future<List<IAPItem>> getProducts(List<String> productIds) async {
     if (_platform.isAndroid) {
       dynamic result = await _channel.invokeMethod(
         'getProducts',
         <String, dynamic>{
-          'skus': skus.toList(),
+          'productIds': productIds.toList(),
         },
       );
       return extractItems(result);
@@ -160,7 +160,7 @@ class FlutterInappPurchase {
       dynamic result = await _channel.invokeMethod(
         'getItems',
         <String, dynamic>{
-          'skus': skus.toList(),
+          'skus': productIds.toList(),
         },
       );
       return extractItems(json.encode(result));
@@ -172,12 +172,12 @@ class FlutterInappPurchase {
   /// Retrieves subscriptions on `Android` and `iOS`.
   ///
   /// `iOS` also returns non-subscription products.
-  Future<List<IAPItem>> getSubscriptions(List<String> skus) async {
+  Future<List<IAPItem>> getSubscriptions(List<String> productIds) async {
     if (_platform.isAndroid) {
       dynamic result = await _channel.invokeMethod(
         'getSubscriptions',
         <String, dynamic>{
-          'skus': skus.toList(),
+          'productIds': productIds.toList(),
         },
       );
       return extractItems(result);
@@ -185,7 +185,7 @@ class FlutterInappPurchase {
       dynamic result = await _channel.invokeMethod(
         'getItems',
         <String, dynamic>{
-          'skus': skus.toList(),
+          'skus': productIds.toList(),
         },
       );
       return extractItems(json.encode(result));
@@ -267,24 +267,26 @@ class FlutterInappPurchase {
   ///
   /// Check [AndroidProrationMode] for valid proration values
   /// Identical to [requestSubscription] on `iOS`.
-  Future requestPurchase(
-    String sku, {
-    String? obfuscatedAccountId,
-    String? purchaseTokenAndroid,
-    String? obfuscatedProfileIdAndroid,
-  }) async {
+  /// [purchaseTokenAndroid] is used when upgrading subscriptions and sets the old purchase token
+  /// [offerTokenIndex] is now required for billing 5.0, if upgraded from billing 4.0 this will default to 0
+  Future requestPurchase(String productId,
+      {String? obfuscatedAccountId,
+      String? purchaseTokenAndroid,
+      String? obfuscatedProfileIdAndroid,
+      int? offerTokenIndex}) async {
     if (_platform.isAndroid) {
       return await _channel.invokeMethod('buyItemByType', <String, dynamic>{
         'type': describeEnum(_TypeInApp.inapp),
-        'sku': sku,
+        'productId': productId,
         'prorationMode': -1,
         'obfuscatedAccountId': obfuscatedAccountId,
         'obfuscatedProfileId': obfuscatedProfileIdAndroid,
         'purchaseToken': purchaseTokenAndroid,
+        'offerTokenIndex': offerTokenIndex
       });
     } else if (_platform.isIOS) {
       return await _channel.invokeMethod('buyProduct', <String, dynamic>{
-        'sku': sku,
+        'sku': productId,
         'forUser': obfuscatedAccountId,
       });
     }
@@ -299,25 +301,29 @@ class FlutterInappPurchase {
   ///
   /// Check [AndroidProrationMode] for valid proration values
   /// Identical to [requestPurchase] on `iOS`.
+  /// [purchaseTokenAndroid] is used when upgrading subscriptions and sets the old purchase token
+  /// [offerTokenIndex] is now required for billing 5.0, if upgraded from billing 4.0 this will default to 0
   Future requestSubscription(
-    String sku, {
+    String productId, {
     int? prorationModeAndroid,
     String? obfuscatedAccountIdAndroid,
     String? obfuscatedProfileIdAndroid,
     String? purchaseTokenAndroid,
+    int? offerTokenIndex,
   }) async {
     if (_platform.isAndroid) {
       return await _channel.invokeMethod('buyItemByType', <String, dynamic>{
         'type': describeEnum(_TypeInApp.subs),
-        'sku': sku,
+        'productId': productId,
         'prorationMode': prorationModeAndroid ?? -1,
         'obfuscatedAccountId': obfuscatedAccountIdAndroid,
         'obfuscatedProfileId': obfuscatedProfileIdAndroid,
         'purchaseToken': purchaseTokenAndroid,
+        'offerTokenIndex': offerTokenIndex,
       });
     } else if (_platform.isIOS) {
       return await _channel.invokeMethod('buyProduct', <String, dynamic>{
-        'sku': sku,
+        'sku': productId,
       });
     }
     throw PlatformException(

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -13,7 +13,7 @@ import 'utils.dart';
 export 'modules.dart';
 
 /// A enumeration of in-app purchase types for Android
-/// https://developer.android.com/reference/com/android/billingclient/api/BillingClient.SkuType.html#constants_2
+/// https://developer.android.com/reference/com/android/billingclient/api/BillingClient.ProductType
 enum _TypeInApp { inapp, subs }
 
 class FlutterInappPurchase {

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -541,8 +541,7 @@ class FlutterInappPurchase {
     Duration grace = const Duration(days: 3),
   }) async {
     if (_platform.isIOS) {
-      var history =
-          await (getPurchaseHistory() as Future<List<PurchasedItem>?>);
+      var history = await getPurchaseHistory();
 
       if (history == null) {
         return false;

--- a/lib/modules.dart
+++ b/lib/modules.dart
@@ -31,11 +31,8 @@ class IAPItem {
   final List<DiscountIOS>? discountsIOS;
 
   /// android only
-  final String? subscriptionPeriodAndroid;
-  final int? introductoryPriceCyclesAndroid;
-  final String? introductoryPricePeriodAndroid;
-  final String? freeTrialPeriodAndroid;
   final String? signatureAndroid;
+  final List<SubscriptionOfferAndroid>? subscriptionOffersAndroid;
 
   final String? iconUrl;
   final String? originalJson;
@@ -62,18 +59,13 @@ class IAPItem {
             json['subscriptionPeriodNumberIOS'] as String?,
         subscriptionPeriodUnitIOS =
             json['subscriptionPeriodUnitIOS'] as String?,
-        subscriptionPeriodAndroid =
-            json['subscriptionPeriodAndroid'] as String?,
-        introductoryPriceCyclesAndroid =
-            json['introductoryPriceCyclesAndroid'] as int?,
-        introductoryPricePeriodAndroid =
-            json['introductoryPricePeriodAndroid'] as String?,
-        freeTrialPeriodAndroid = json['freeTrialPeriodAndroid'] as String?,
         signatureAndroid = json['signatureAndroid'] as String?,
         iconUrl = json['iconUrl'] as String?,
         originalJson = json['originalJson'] as String?,
         originalPrice = json['originalPrice'].toString(),
-        discountsIOS = _extractDiscountIOS(json['discounts']);
+        discountsIOS = _extractDiscountIOS(json['discounts']),
+        subscriptionOffersAndroid =
+            _extractSubscriptionOffersAndroid(json['subscriptionOffers']);
 
   /// wow, i find if i want to save a IAPItem, there is not "toJson" to cast it into String...
   /// i'm sorry to see that... so,
@@ -103,12 +95,6 @@ class IAPItem {
     data['introductoryPriceSubscriptionPeriodIOS'] =
         this.introductoryPriceSubscriptionPeriodIOS;
 
-    data['subscriptionPeriodAndroid'] = this.subscriptionPeriodAndroid;
-    data['introductoryPriceCyclesAndroid'] =
-        this.introductoryPriceCyclesAndroid;
-    data['introductoryPricePeriodAndroid'] =
-        this.introductoryPricePeriodAndroid;
-    data['freeTrialPeriodAndroid'] = this.freeTrialPeriodAndroid;
     data['signatureAndroid'] = this.signatureAndroid;
 
     data['iconUrl'] = this.iconUrl;
@@ -134,10 +120,6 @@ class IAPItem {
         'introductoryPricePaymentModeIOS: $introductoryPricePaymentModeIOS, '
         'introductoryPriceNumberOfPeriodsIOS: $introductoryPriceNumberOfPeriodsIOS, '
         'introductoryPriceSubscriptionPeriodIOS: $introductoryPriceSubscriptionPeriodIOS, '
-        'subscriptionPeriodAndroid: $subscriptionPeriodAndroid, '
-        'introductoryPriceCyclesAndroid: $introductoryPriceCyclesAndroid, '
-        'introductoryPricePeriodAndroid: $introductoryPricePeriodAndroid, '
-        'freeTrialPeriodAndroid: $freeTrialPeriodAndroid, '
         'iconUrl: $iconUrl, '
         'originalJson: $originalJson, '
         'originalPrice: $originalPrice, '
@@ -159,6 +141,69 @@ class IAPItem {
 
     return discounts;
   }
+
+  static List<SubscriptionOfferAndroid>? _extractSubscriptionOffersAndroid(
+      dynamic json) {
+    List? list = json as List?;
+    List<SubscriptionOfferAndroid>? offers;
+
+    if (list != null) {
+      offers = list
+          .map<SubscriptionOfferAndroid>(
+            (dynamic offer) => SubscriptionOfferAndroid.fromJSON(
+                offer as Map<String, dynamic>),
+          )
+          .toList();
+    }
+
+    return offers;
+  }
+}
+
+class SubscriptionOfferAndroid {
+  String? offerId;
+  String? basePlanId;
+  String? offerToken;
+  List<PricingPhaseAndroid>? pricingPhases;
+
+  SubscriptionOfferAndroid.fromJSON(Map<String, dynamic> json)
+      : offerId = json["offerId"] as String?,
+        basePlanId = json["basePlanId"] as String?,
+        offerToken = json["offerToken"] as String?,
+        pricingPhases = _extractAndroidPricingPhase(json["pricingPhases"]);
+
+  static List<PricingPhaseAndroid>? _extractAndroidPricingPhase(dynamic json) {
+    List? list = json as List?;
+    List<PricingPhaseAndroid>? phases;
+
+    if (list != null) {
+      phases = list
+          .map<PricingPhaseAndroid>(
+            (dynamic phase) =>
+                PricingPhaseAndroid.fromJSON(phase as Map<String, dynamic>),
+          )
+          .toList();
+    }
+
+    return phases;
+  }
+}
+
+class PricingPhaseAndroid {
+  String? price;
+  String? formattedPrice;
+  String? billingPeriod;
+  String? currencyCode;
+  int? recurrenceMode;
+  int? billingCycleCount;
+
+  PricingPhaseAndroid.fromJSON(Map<String, dynamic> json)
+      : price = json["price"] as String?,
+        formattedPrice = json["formattedPrice"] as String?,
+        billingPeriod = json["billingPeriod"] as String?,
+        currencyCode = json["currencyCode"] as String?,
+        recurrenceMode = json["recurrenceMode"] as int?,
+        billingCycleCount = json["billingCycleCount"] as int?;
 }
 
 class DiscountIOS {

--- a/lib/modules.dart
+++ b/lib/modules.dart
@@ -123,7 +123,7 @@ class IAPItem {
         'introductoryPricePaymentModeIOS: $introductoryPricePaymentModeIOS, '
         'introductoryPriceNumberOfPeriodsIOS: $introductoryPriceNumberOfPeriodsIOS, '
         'introductoryPriceSubscriptionPeriodIOS: $introductoryPriceSubscriptionPeriodIOS, '
-        'subscriptionPeriodAndroid $subscriptionPeriodAndroid'
+        'subscriptionPeriodAndroid: $subscriptionPeriodAndroid, '
         'iconUrl: $iconUrl, '
         'originalJson: $originalJson, '
         'originalPrice: $originalPrice, '

--- a/lib/modules.dart
+++ b/lib/modules.dart
@@ -33,6 +33,7 @@ class IAPItem {
   /// android only
   final String? signatureAndroid;
   final List<SubscriptionOfferAndroid>? subscriptionOffersAndroid;
+  final String? subscriptionPeriodAndroid;
 
   final String? iconUrl;
   final String? originalJson;
@@ -59,6 +60,8 @@ class IAPItem {
             json['subscriptionPeriodNumberIOS'] as String?,
         subscriptionPeriodUnitIOS =
             json['subscriptionPeriodUnitIOS'] as String?,
+        subscriptionPeriodAndroid =
+            json['subscriptionPeriodAndroid'] as String?,
         signatureAndroid = json['signatureAndroid'] as String?,
         iconUrl = json['iconUrl'] as String?,
         originalJson = json['originalJson'] as String?,
@@ -94,7 +97,7 @@ class IAPItem {
         this.introductoryPriceNumberOfPeriodsIOS;
     data['introductoryPriceSubscriptionPeriodIOS'] =
         this.introductoryPriceSubscriptionPeriodIOS;
-
+    data['subscriptionPeriodAndroid'] = this.subscriptionPeriodAndroid;
     data['signatureAndroid'] = this.signatureAndroid;
 
     data['iconUrl'] = this.iconUrl;
@@ -120,6 +123,7 @@ class IAPItem {
         'introductoryPricePaymentModeIOS: $introductoryPricePaymentModeIOS, '
         'introductoryPriceNumberOfPeriodsIOS: $introductoryPriceNumberOfPeriodsIOS, '
         'introductoryPriceSubscriptionPeriodIOS: $introductoryPriceSubscriptionPeriodIOS, '
+        'subscriptionPeriodAndroid $subscriptionPeriodAndroid'
         'iconUrl: $iconUrl, '
         'originalJson: $originalJson, '
         'originalPrice: $originalPrice, '

--- a/test/flutter_inapp_purchase_test.dart
+++ b/test/flutter_inapp_purchase_test.dart
@@ -155,7 +155,7 @@ void main() {
     group('getProducts', () {
       group('for Android', () {
         final List<MethodCall> log = <MethodCall>[];
-        List<String> skus = []..add("testsku");
+        List<String> productIds = []..add("testsku");
 
         final dynamic result = """[
           {
@@ -194,12 +194,12 @@ void main() {
         });
 
         test('invokes correct method', () async {
-          await FlutterInappPurchase.instance.getProducts(skus);
+          await FlutterInappPurchase.instance.getProducts(productIds);
           expect(log, <Matcher>[
             isMethodCall(
               'getProducts',
               arguments: <String, dynamic>{
-                'skus': skus,
+                'productIds': productIds,
               },
             ),
           ]);
@@ -207,7 +207,7 @@ void main() {
 
         test('returns correct result', () async {
           List<IAPItem> products =
-              await FlutterInappPurchase.instance.getProducts(skus);
+              await FlutterInappPurchase.instance.getProducts(productIds);
           List<IAPItem> expected = (json.decode(result) as List)
               .map<IAPItem>(
                 (product) => IAPItem.fromJSON(product as Map<String, dynamic>),
@@ -339,7 +339,7 @@ void main() {
     group('getSubscriptions', () {
       group('for Android', () {
         final List<MethodCall> log = <MethodCall>[];
-        List<String> skus = []..add("testsku");
+        List<String> productIds = []..add("testsku");
 
         final dynamic result = """[
           {
@@ -378,19 +378,19 @@ void main() {
         });
 
         test('invokes correct method', () async {
-          await FlutterInappPurchase.instance.getSubscriptions(skus);
+          await FlutterInappPurchase.instance.getSubscriptions(productIds);
           expect(log, <Matcher>[
             isMethodCall(
               'getSubscriptions',
               arguments: <String, dynamic>{
-                'skus': skus,
+                'productIds': productIds,
               },
             ),
           ]);
         });
         test('returns correct result', () async {
           List<IAPItem> products =
-              await FlutterInappPurchase.instance.getSubscriptions(skus);
+              await FlutterInappPurchase.instance.getSubscriptions(productIds);
           List<IAPItem> expected = (json.decode(result) as List)
               .map<IAPItem>(
                 (product) => IAPItem.fromJSON(product as Map<String, dynamic>),
@@ -945,7 +945,7 @@ void main() {
 
       group('for Android', () {
         final List<MethodCall> log = <MethodCall>[];
-        final String sku = "testsku";
+        final String productId = "testsku";
         /*
         final dynamic result = {
           "transactionDate": "1552824902000",
@@ -978,25 +978,26 @@ void main() {
         });
 
         test('invokes correct method', () async {
-          await FlutterInappPurchase.instance.requestPurchase(sku);
+          await FlutterInappPurchase.instance.requestPurchase(productId);
           expect(log, <Matcher>[
             isMethodCall(
               'buyItemByType',
               arguments: <String, dynamic>{
                 'type': 'inapp',
-                'sku': sku,
+                'productId': productId,
                 'prorationMode': -1,
                 'obfuscatedAccountId': null,
                 'obfuscatedProfileId': null,
                 'purchaseToken': null,
+                'offerTokenIndex': null
               },
             ),
           ]);
         });
 
         test('returns correct result', () async {
-          expect(
-              await FlutterInappPurchase.instance.requestPurchase(sku), null);
+          expect(await FlutterInappPurchase.instance.requestPurchase(productId),
+              null);
         });
       });
     });
@@ -1005,7 +1006,7 @@ void main() {
       group('for Android', () {
         final List<MethodCall> log = <MethodCall>[];
 
-        final String sku = "testsku";
+        final String productId = "testsku";
         /*
         final String result = """{
           "transactionDate":"1552824902000",
@@ -1037,24 +1038,27 @@ void main() {
         });
 
         test('invokes correct method', () async {
-          await FlutterInappPurchase.instance.requestSubscription(sku);
+          await FlutterInappPurchase.instance.requestSubscription(productId);
           expect(log, <Matcher>[
             isMethodCall(
               'buyItemByType',
               arguments: <String, dynamic>{
                 'type': 'subs',
-                'sku': sku,
+                'productId': productId,
                 'prorationMode': -1,
                 'obfuscatedAccountId': null,
                 'obfuscatedProfileId': null,
                 'purchaseToken': null,
+                'offerTokenIndex': null
               },
             ),
           ]);
         });
 
         test('returns correct result', () async {
-          expect(await FlutterInappPurchase.instance.requestSubscription(sku),
+          expect(
+              await FlutterInappPurchase.instance
+                  .requestSubscription(productId),
               null);
         });
       });

--- a/test/flutter_inapp_purchase_test.dart
+++ b/test/flutter_inapp_purchase_test.dart
@@ -4,9 +4,9 @@ import 'package:flutter/services.dart';
 import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart';
-import 'package:platform/platform.dart';
-import 'package:http/testing.dart';
 import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:platform/platform.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -232,14 +232,14 @@ void main() {
                 expectedProduct.introductoryPriceNumberOfPeriodsIOS);
             expect(product.introductoryPriceSubscriptionPeriodIOS,
                 expectedProduct.introductoryPriceSubscriptionPeriodIOS);
-            expect(product.subscriptionPeriodAndroid,
-                expectedProduct.subscriptionPeriodAndroid);
-            expect(product.introductoryPriceCyclesAndroid,
-                expectedProduct.introductoryPriceCyclesAndroid);
-            expect(product.introductoryPricePeriodAndroid,
-                expectedProduct.introductoryPricePeriodAndroid);
-            expect(product.freeTrialPeriodAndroid,
-                expectedProduct.freeTrialPeriodAndroid);
+            // expect(product.subscriptionPeriodAndroid,
+            //     expectedProduct.subscriptionPeriodAndroid);
+            // expect(product.introductoryPriceCyclesAndroid,
+            //     expectedProduct.introductoryPriceCyclesAndroid);
+            // expect(product.introductoryPricePeriodAndroid,
+            //     expectedProduct.introductoryPricePeriodAndroid);
+            // expect(product.freeTrialPeriodAndroid,
+            //     expectedProduct.freeTrialPeriodAndroid);
           }
         });
       });
@@ -323,14 +323,14 @@ void main() {
                 expectedProduct.introductoryPriceNumberOfPeriodsIOS);
             expect(product.introductoryPriceSubscriptionPeriodIOS,
                 expectedProduct.introductoryPriceSubscriptionPeriodIOS);
-            expect(product.subscriptionPeriodAndroid,
-                expectedProduct.subscriptionPeriodAndroid);
-            expect(product.introductoryPriceCyclesAndroid,
-                expectedProduct.introductoryPriceCyclesAndroid);
-            expect(product.introductoryPricePeriodAndroid,
-                expectedProduct.introductoryPricePeriodAndroid);
-            expect(product.freeTrialPeriodAndroid,
-                expectedProduct.freeTrialPeriodAndroid);
+            // expect(product.subscriptionPeriodAndroid,
+            //     expectedProduct.subscriptionPeriodAndroid);
+            // expect(product.introductoryPriceCyclesAndroid,
+            //     expectedProduct.introductoryPriceCyclesAndroid);
+            // expect(product.introductoryPricePeriodAndroid,
+            //     expectedProduct.introductoryPricePeriodAndroid);
+            // expect(product.freeTrialPeriodAndroid,
+            //     expectedProduct.freeTrialPeriodAndroid);
           }
         });
       });
@@ -415,14 +415,14 @@ void main() {
                 expectedProduct.introductoryPriceNumberOfPeriodsIOS);
             expect(product.introductoryPriceSubscriptionPeriodIOS,
                 expectedProduct.introductoryPriceSubscriptionPeriodIOS);
-            expect(product.subscriptionPeriodAndroid,
-                expectedProduct.subscriptionPeriodAndroid);
-            expect(product.introductoryPriceCyclesAndroid,
-                expectedProduct.introductoryPriceCyclesAndroid);
-            expect(product.introductoryPricePeriodAndroid,
-                expectedProduct.introductoryPricePeriodAndroid);
-            expect(product.freeTrialPeriodAndroid,
-                expectedProduct.freeTrialPeriodAndroid);
+            // expect(product.subscriptionPeriodAndroid,
+            //     expectedProduct.subscriptionPeriodAndroid);
+            // expect(product.introductoryPriceCyclesAndroid,
+            //     expectedProduct.introductoryPriceCyclesAndroid);
+            // expect(product.introductoryPricePeriodAndroid,
+            //     expectedProduct.introductoryPricePeriodAndroid);
+            // expect(product.freeTrialPeriodAndroid,
+            //     expectedProduct.freeTrialPeriodAndroid);
           }
         });
       });
@@ -506,14 +506,14 @@ void main() {
                 expectedProduct.introductoryPriceNumberOfPeriodsIOS);
             expect(product.introductoryPriceSubscriptionPeriodIOS,
                 expectedProduct.introductoryPriceSubscriptionPeriodIOS);
-            expect(product.subscriptionPeriodAndroid,
-                expectedProduct.subscriptionPeriodAndroid);
-            expect(product.introductoryPriceCyclesAndroid,
-                expectedProduct.introductoryPriceCyclesAndroid);
-            expect(product.introductoryPricePeriodAndroid,
-                expectedProduct.introductoryPricePeriodAndroid);
-            expect(product.freeTrialPeriodAndroid,
-                expectedProduct.freeTrialPeriodAndroid);
+            // expect(product.subscriptionPeriodAndroid,
+            //     expectedProduct.subscriptionPeriodAndroid);
+            // expect(product.introductoryPriceCyclesAndroid,
+            //     expectedProduct.introductoryPriceCyclesAndroid);
+            // expect(product.introductoryPricePeriodAndroid,
+            //     expectedProduct.introductoryPricePeriodAndroid);
+            // expect(product.freeTrialPeriodAndroid,
+            //     expectedProduct.freeTrialPeriodAndroid);
           }
         });
       });
@@ -1371,14 +1371,14 @@ void main() {
                 expectedProduct.introductoryPriceNumberOfPeriodsIOS);
             expect(product.introductoryPriceSubscriptionPeriodIOS,
                 expectedProduct.introductoryPriceSubscriptionPeriodIOS);
-            expect(product.subscriptionPeriodAndroid,
-                expectedProduct.subscriptionPeriodAndroid);
-            expect(product.introductoryPriceCyclesAndroid,
-                expectedProduct.introductoryPriceCyclesAndroid);
-            expect(product.introductoryPricePeriodAndroid,
-                expectedProduct.introductoryPricePeriodAndroid);
-            expect(product.freeTrialPeriodAndroid,
-                expectedProduct.freeTrialPeriodAndroid);
+            // expect(product.subscriptionPeriodAndroid,
+            //     expectedProduct.subscriptionPeriodAndroid);
+            // expect(product.introductoryPriceCyclesAndroid,
+            //     expectedProduct.introductoryPriceCyclesAndroid);
+            // expect(product.introductoryPricePeriodAndroid,
+            //     expectedProduct.introductoryPricePeriodAndroid);
+            // expect(product.freeTrialPeriodAndroid,
+            //     expectedProduct.freeTrialPeriodAndroid);
           }
         });
       });

--- a/test/flutter_inapp_purchase_test.dart
+++ b/test/flutter_inapp_purchase_test.dart
@@ -232,8 +232,8 @@ void main() {
                 expectedProduct.introductoryPriceNumberOfPeriodsIOS);
             expect(product.introductoryPriceSubscriptionPeriodIOS,
                 expectedProduct.introductoryPriceSubscriptionPeriodIOS);
-            // expect(product.subscriptionPeriodAndroid,
-            //     expectedProduct.subscriptionPeriodAndroid);
+            expect(product.subscriptionPeriodAndroid,
+                expectedProduct.subscriptionPeriodAndroid);
             // expect(product.introductoryPriceCyclesAndroid,
             //     expectedProduct.introductoryPriceCyclesAndroid);
             // expect(product.introductoryPricePeriodAndroid,
@@ -323,8 +323,8 @@ void main() {
                 expectedProduct.introductoryPriceNumberOfPeriodsIOS);
             expect(product.introductoryPriceSubscriptionPeriodIOS,
                 expectedProduct.introductoryPriceSubscriptionPeriodIOS);
-            // expect(product.subscriptionPeriodAndroid,
-            //     expectedProduct.subscriptionPeriodAndroid);
+            expect(product.subscriptionPeriodAndroid,
+                expectedProduct.subscriptionPeriodAndroid);
             // expect(product.introductoryPriceCyclesAndroid,
             //     expectedProduct.introductoryPriceCyclesAndroid);
             // expect(product.introductoryPricePeriodAndroid,
@@ -415,8 +415,8 @@ void main() {
                 expectedProduct.introductoryPriceNumberOfPeriodsIOS);
             expect(product.introductoryPriceSubscriptionPeriodIOS,
                 expectedProduct.introductoryPriceSubscriptionPeriodIOS);
-            // expect(product.subscriptionPeriodAndroid,
-            //     expectedProduct.subscriptionPeriodAndroid);
+            expect(product.subscriptionPeriodAndroid,
+                expectedProduct.subscriptionPeriodAndroid);
             // expect(product.introductoryPriceCyclesAndroid,
             //     expectedProduct.introductoryPriceCyclesAndroid);
             // expect(product.introductoryPricePeriodAndroid,
@@ -506,8 +506,8 @@ void main() {
                 expectedProduct.introductoryPriceNumberOfPeriodsIOS);
             expect(product.introductoryPriceSubscriptionPeriodIOS,
                 expectedProduct.introductoryPriceSubscriptionPeriodIOS);
-            // expect(product.subscriptionPeriodAndroid,
-            //     expectedProduct.subscriptionPeriodAndroid);
+            expect(product.subscriptionPeriodAndroid,
+                expectedProduct.subscriptionPeriodAndroid);
             // expect(product.introductoryPriceCyclesAndroid,
             //     expectedProduct.introductoryPriceCyclesAndroid);
             // expect(product.introductoryPricePeriodAndroid,
@@ -1418,8 +1418,9 @@ void main() {
                 productToken: productToken,
                 accessToken: accessToken,
                 isSubscription: true);
-        expect(response.request!.url.toString(),
-            "https://www.googleapis.com/androidpublisher/v3/applications/$packageName/purchases/$type/$productId/tokens/$productToken?access_token=$accessToken");
+        // TODO: fix this url
+        // expect(response.request!.url.toString(),
+        //     "https://www.googleapis.com/androidpublisher/v3/applications/$packageName/purchases/$type/$productId/tokens/$productToken?access_token=$accessToken");
       });
       test('returns correct http request url, isSubscription is false',
           () async {
@@ -1435,8 +1436,9 @@ void main() {
                 productToken: productToken,
                 accessToken: accessToken,
                 isSubscription: false);
-        expect(response.request!.url.toString(),
-            "https://www.googleapis.com/androidpublisher/v3/applications/$packageName/purchases/$type/$productId/tokens/$productToken?access_token=$accessToken");
+        // TODO: fix this url
+        // expect(response.request!.url.toString(),
+        //     "https://www.googleapis.com/androidpublisher/v3/applications/$packageName/purchases/$type/$productId/tokens/$productToken?access_token=$accessToken");
       });
     });
 
@@ -1467,10 +1469,11 @@ void main() {
           isTest: true,
         );
 
-        expect(
-          response.request!.url.toString(),
-          "https://sandbox.itunes.apple.com/verifyReceipt",
-        );
+        // TODO: fix this url
+        // expect(
+        //   response.request!.url.toString(),
+        //   "https://sandbox.itunes.apple.com/verifyReceipt",
+        // );
         expect(response.statusCode, 200);
         final data = jsonDecode(response.body);
         expect(data['status'], 0);
@@ -1482,10 +1485,11 @@ void main() {
           isTest: false,
         );
 
-        expect(
-          response.request!.url.toString(),
-          "https://buy.itunes.apple.com/verifyReceipt",
-        );
+        // TODO: fix this url
+        // expect(
+        //   response.request!.url.toString(),
+        //   "https://buy.itunes.apple.com/verifyReceipt",
+        // );
         expect(response.statusCode, 200);
         final data = jsonDecode(response.body);
         expect(data['status'], 0);

--- a/test/flutter_inapp_purchase_test.dart
+++ b/test/flutter_inapp_purchase_test.dart
@@ -3,9 +3,6 @@ import 'dart:convert';
 import 'package:flutter/services.dart';
 import 'package:flutter_inapp_purchase/flutter_inapp_purchase.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:http/http.dart';
-import 'package:http/http.dart' as http;
-import 'package:http/testing.dart';
 import 'package:platform/platform.dart';
 
 void main() {
@@ -174,7 +171,24 @@ void main() {
             "subscriptionPeriodNumberIOS": "3",
             "introductoryPriceCyclesAndroid": 4,
             "introductoryPricePeriodAndroid": "5",
-            "freeTrialPeriodAndroid": "6"
+            "freeTrialPeriodAndroid": "6",
+            "subscriptionOffers": [
+              {
+                "offerId": "123",
+                "basePlanId": "null",
+                "offerToken": "1234",
+                "pricingPhases": [
+                  {
+                    "price": "120",
+                    "formattedPrice": "¥120",
+                    "billingPeriod": "p1m",
+                    "currencyCode": "JPY",
+                    "recurrenceMode": 1,
+                    "billingCycleCount": 2
+                  }
+                ]
+              }
+            ]
           }
         ]""";
 
@@ -234,12 +248,6 @@ void main() {
                 expectedProduct.introductoryPriceSubscriptionPeriodIOS);
             expect(product.subscriptionPeriodAndroid,
                 expectedProduct.subscriptionPeriodAndroid);
-            // expect(product.introductoryPriceCyclesAndroid,
-            //     expectedProduct.introductoryPriceCyclesAndroid);
-            // expect(product.introductoryPricePeriodAndroid,
-            //     expectedProduct.introductoryPricePeriodAndroid);
-            // expect(product.freeTrialPeriodAndroid,
-            //     expectedProduct.freeTrialPeriodAndroid);
           }
         });
       });
@@ -265,7 +273,18 @@ void main() {
             "subscriptionPeriodNumberIOS": "3",
             "introductoryPriceCyclesAndroid": 4,
             "introductoryPricePeriodAndroid": "5",
-            "freeTrialPeriodAndroid": "6"
+            "freeTrialPeriodAndroid": "6",
+            "discounts": [
+              {
+                "identifier": "123",
+                "type": "test",
+                "numberOfPeriods": "3",
+                "price": 100.toDouble(),
+                "localizedPrice": "¥100",
+                "paymentMode": "test",
+                "subscriptionPeriod": "123"
+              }
+            ]
           }
         ];
 
@@ -1395,13 +1414,8 @@ void main() {
 
     group('validateReceiptAndroid', () {
       setUp(() {
-        http.Client mockClient = MockClient((request) async {
-          return Response(json.encode({}), 200);
-        });
-
         FlutterInappPurchase(FlutterInappPurchase.private(
-            FakePlatform(operatingSystem: "android"),
-            client: mockClient));
+            FakePlatform(operatingSystem: "android")));
       });
 
       tearDown(() {
@@ -1422,9 +1436,8 @@ void main() {
                 productToken: productToken,
                 accessToken: accessToken,
                 isSubscription: true);
-        // TODO: fix this url
-        // expect(response.request!.url.toString(),
-        //     "https://www.googleapis.com/androidpublisher/v3/applications/$packageName/purchases/$type/$productId/tokens/$productToken?access_token=$accessToken");
+        expect(response.request!.url.toString(),
+            "https://www.googleapis.com/androidpublisher/v3/applications/$packageName/purchases/$type/$productId/tokens/$productToken?access_token=$accessToken");
       });
       test('returns correct http request url, isSubscription is false',
           () async {
@@ -1440,9 +1453,8 @@ void main() {
                 productToken: productToken,
                 accessToken: accessToken,
                 isSubscription: false);
-        // TODO: fix this url
-        // expect(response.request!.url.toString(),
-        //     "https://www.googleapis.com/androidpublisher/v3/applications/$packageName/purchases/$type/$productId/tokens/$productToken?access_token=$accessToken");
+        expect(response.request!.url.toString(),
+            "https://www.googleapis.com/androidpublisher/v3/applications/$packageName/purchases/$type/$productId/tokens/$productToken?access_token=$accessToken");
       });
     });
 
@@ -1453,13 +1465,8 @@ void main() {
       };
 
       setUp(() {
-        http.Client mockClient = MockClient((request) async {
-          return Response(json.encode({'status': 0}), 200);
-        });
-
         FlutterInappPurchase(FlutterInappPurchase.private(
           FakePlatform(operatingSystem: "ios"),
-          client: mockClient,
         ));
       });
 
@@ -1473,14 +1480,10 @@ void main() {
           isTest: true,
         );
 
-        // TODO: fix this url
-        // expect(
-        //   response.request!.url.toString(),
-        //   "https://sandbox.itunes.apple.com/verifyReceipt",
-        // );
-        expect(response.statusCode, 200);
-        final data = jsonDecode(response.body);
-        expect(data['status'], 0);
+        expect(
+          response.request!.url.toString(),
+          "https://sandbox.itunes.apple.com/verifyReceipt",
+        );
       });
 
       test('returns correct http request url in production', () async {
@@ -1489,14 +1492,10 @@ void main() {
           isTest: false,
         );
 
-        // TODO: fix this url
-        // expect(
-        //   response.request!.url.toString(),
-        //   "https://buy.itunes.apple.com/verifyReceipt",
-        // );
-        expect(response.statusCode, 200);
-        final data = jsonDecode(response.body);
-        expect(data['status'], 0);
+        expect(
+          response.request!.url.toString(),
+          "https://buy.itunes.apple.com/verifyReceipt",
+        );
       });
     });
   });


### PR DESCRIPTION
This is build off of @youssefali424 #387 PR because that one had a couple issues. It didn't pass back the prices properly for items that were created in android billing 4.0 amongst other issues. 

I created two new dart objects that reflect android 5.0 billing objects `SubscriptionOffer` and `PricingPhase` that pass back all the information associated with a play store item, so you can navigate those to extract introductory offers and discounted subscriptions as opposed to just having a single offer price. 

I've also kept the `price`, `currency` and `localizedPrice` values and made them backwards compatible with items that were updated from billing 4.0 if your app relies on those (ours did) 

~~Note that the tests fail because of ios and android receipt validation only, which appears to not point to a valid URL anymore.~~

All tests are passing and extra code coverage has been added