### PR TITLE
Fixed concurrency issue on iOS.

### DIFF
--- a/ios/Classes/FlutterInappPurchasePlugin.m
+++ b/ios/Classes/FlutterInappPurchasePlugin.m
@@ -286,21 +286,23 @@
 }
 
 - (void)productsRequest:(nonnull SKProductsRequest *)request didReceiveResponse:(nonnull SKProductsResponse *)response {
-    NSValue* key = [NSValue valueWithNonretainedObject:request];
-    FlutterResult result = [fetchProducts objectForKey:key];
-    if (result == nil) return;
-    [fetchProducts removeObjectForKey:key];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSValue* key = [NSValue valueWithNonretainedObject:request];
+        FlutterResult result = [self.fetchProducts objectForKey:key];
+        if (result == nil) return;
+        [self.fetchProducts removeObjectForKey:key];
 
-    for (SKProduct* prod in response.products) {
-        [self addProduct:prod];
-    }
-    NSMutableArray* items = [NSMutableArray array];
-    
-    for (SKProduct* product in validProducts) {
-        [items addObject:[self getProductObject:product]];
-    }
+        for (SKProduct* prod in response.products) {
+            [self addProduct:prod];
+        }
+        NSMutableArray* items = [NSMutableArray array];
 
-    result(items);
+        for (SKProduct* product in self->validProducts) {
+            [items addObject:[self getProductObject:product]];
+        }
+
+        result(items);
+    });
 }
 
 -(void)addProduct:(SKProduct *)aProd {


### PR DESCRIPTION
The `productsRequest` method as per Apple docs can be called on any thread (source: https://developer.apple.com/documentation/storekit/skproductsrequestdelegate (please check text in read)). 
Working with `validProducts` on such thread can cause concurrency issues, such as this one:
**"Terminating app due to uncaught exception 'NSGenericException', reason: '*** Collection <__NSArrayM: 0x283ca4090> was mutated while being enumerated.'"**

Moreover, flutter results must be called on platform main thread only (source: https://docs.flutter.dev/development/platform-integration/platform-channels)
_"Even though Flutter sends messages to and from Dart asynchronously, whenever you invoke a channel method, you must invoke that method on the platform’s main thread."_

To fix these issues I simply wrapped all the code in `dispatch_async(dispatch_get_main_queue, ^{ ... })`. 
Please pull this fix.
